### PR TITLE
Add Turbo Mode, G30 Verge/T2252 & update Vacuum status 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,51 @@ The ‘LocalKey’ is 16 characters long & the ‘devID’ is 21 characters long
 It looks like you need an older version of the EufyHome app to be able to get the LOCAL KEY and DEVICE ID. 
 
 <Update with somewhat accurate instructions to gain the required info>
+  
+  
+  You will need a chromebook for the below instructions. Said chromebook will need to have developer mode active, and the terminal enabled.
+  
+  You will also need to download the following file, or another copy of Eufyhome at least version 2.4.0: https://drive.google.com/file/d/1qoq03H6Gz_oPSUtwhAaRXDyDNq-T_p4n/view?usp=sharing
+  
+  Download the file to the "Linux files" location on the chrombook. Unzip if needed to make just .apk.
+  
+  Next, Install ADB and tools:
+  
+  ```sudo apt-get install android-tools-adb -y```
+  
+  In the terminal, navigate to the linux files/where you placed the aforementioend app file.
+  
+  Now, sideload the app in with ADB:
+  
+  ``` adb -s emulator-5554 install EufyHome_2.4.0_vevs.apk ```
+  
+  (the -s emulator-5554 tells adb which emulator to use, this should be the same as yours)
+  
+  
+  Now, Eufyhome should be installed on your chromebook as an app, unless im missing a step...
+  
+  Run the following to enter into the shell:
+  
+  ```adb -s emulator-5554 shell```
+  
+  And you can do your own adb logcat commands, Or, run the following to get the tuya info you need:
+  
+ ``` adb -s emulator-5554 shell logcat -e 'tuya.m.my.group.device.relation.list' ```
+  
+  
+  With that running in the terminal, open the app on your chromebook, and login using your Eufy credentials, There may be a ton of output from the logcat. But the command above should spit out a big block of text, that will contain:
+  
+  ```"devId":"21-22 alphanumeric",```
+  
+  ```,"localKey":"16 Alphanumeric"}],"a":"```
+  
+  Insert the info gained into the above Home Assitant config Block, and you should be good to go.
+  
 
 
-Restart HA.
+Yes, you must Restart HA to get the config in place.
+  
+  
 
 ## Using Manual Process
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,14 @@ eufy_vacuum:
    
 **35C** T2117 
 
+---
 
-
+The ‘LocalKey’ is 16 characters long & the ‘devID’ is 21 characters long.
 
 It looks like you need an older version of the EufyHome app to be able to get the LOCAL KEY and DEVICE ID. 
+
+<Update with somewhat accurate instructions to gain the required info>
+
 
 Restart HA.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,24 @@ eufy_vacuum:
     address: 192.168.1.80
     access_token: YOUR LOCAL KEY HERE
     id: YOUR DEVICE ID HERE
-    type: T2118
+    type: MODEL CODE (Below)
 ```
+
+**30C** T2118 
+
+**G30 Edge** T2251 
+
+**G30 Hybrid** T2253 
+
+**25C** T2123 
+
+**11C** T2103 
+   
+**35C** T2117 
+
+
+
+
 It looks like you need an older version of the EufyHome app to be able to get the LOCAL KEY and DEVICE ID. 
 
 Restart HA.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ eufy_vacuum:
     type: MODEL CODE (Below)
 ```
 
+**Available Model Codes:**
+
 **30C** T2118 
 
 **G30 Edge** T2251 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eufy Robovac control for Python
 
-Work in progress! This is a fork of a fork. 
+Work in progress! This is a fork of a fork, of a fork, its forkception
 
 ## Installation
 Pre-requisites:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ It looks like you need an older version of the EufyHome app to be able to get th
 Yes, you must Restart HA to get the config in place.
   
   
+ Once comfirmed good, **UNINSTALL THE APP**, its useless to use, and a security issue. If you need the key again, just do the process over, it takes a few minutes.
+  
 
 ## Using Manual Process
 

--- a/custom_components/eufy_vacuum/robovac.py
+++ b/custom_components/eufy_vacuum/robovac.py
@@ -57,6 +57,7 @@ class CleanSpeed(StringEnum):
     NO_SUCTION = 'No_suction'
     STANDARD = 'Standard'
     BOOST_IQ = 'Boost_IQ'
+    TURBO = 'Turbo'
     MAX = 'Max'
 
 

--- a/custom_components/eufy_vacuum/vacuum.py
+++ b/custom_components/eufy_vacuum/vacuum.py
@@ -80,7 +80,6 @@ SUPPORT_ROBOVAC_T2117 = (
     SUPPORT_TURN_OFF | SUPPORT_TURN_ON
 )
 
- """ Got the other models from https://community.home-assistant.io/t/eufy-robovac-35c-working-with-home-assistant-updated-11-2020-how-to-guide-now-with-edge-cleaning/152690/137"""
 
 MODEL_CONFIG = {
     """ 30C T2118 """

--- a/custom_components/eufy_vacuum/vacuum.py
+++ b/custom_components/eufy_vacuum/vacuum.py
@@ -42,21 +42,82 @@ SUPPORT_ROBOVAC_T2118 = (
 )
 
 """Added to support the G30 Verge without needing to use the same T2118 in HA config"""
+SUPPORT_ROBOVAC_T2251 = (
+    SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
+    SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+)
+
+""" The below needs to be updated with the actual features the vac has """
+
 SUPPORT_ROBOVAC_T2252 = (
     SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
     SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
     SUPPORT_TURN_OFF | SUPPORT_TURN_ON
 )
 
+SUPPORT_ROBOVAC_T2253 = (
+    SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
+    SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+)
+
+SUPPORT_ROBOVAC_T2123 = (
+    SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
+    SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+)
+
+SUPPORT_ROBOVAC_T2103 = (
+    SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
+    SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+)
+
+SUPPORT_ROBOVAC_T2117 = (
+    SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
+    SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+)
+
+ """ Got the other models from https://community.home-assistant.io/t/eufy-robovac-35c-working-with-home-assistant-updated-11-2020-how-to-guide-now-with-edge-cleaning/152690/137"""
 
 MODEL_CONFIG = {
+    """ 30C T2118 """
     'T2118': {
         'fan_speeds': FAN_SPEEDS,
         'support': SUPPORT_ROBOVAC_T2118
     },
+    """ G30 Edge T2251 """
+    'T2251': {
+        'fan_speeds': FAN_SPEEDS,
+        'support': SUPPORT_ROBOVAC_T2251
+    },
+    """ G30 Verge"""
     'T2252': {
         'fan_speeds': FAN_SPEEDS,
-        'support': SUPPORT_ROBOVAC_T2118
+        'support': SUPPORT_ROBOVAC_T2252
+    },
+    """ G30 Hybrid T2253 """
+    'T2253': {
+        'fan_speeds': FAN_SPEEDS,
+        'support': SUPPORT_ROBOVAC_T2253
+    },
+    
+    """ 25C T2123 """
+    'T2123': {
+        'fan_speeds': FAN_SPEEDS,
+        'support': SUPPORT_ROBOVAC_T2123
+    },
+    """ 11C T2103 """
+    'T2103': {
+        'fan_speeds': FAN_SPEEDS,
+        'support': SUPPORT_ROBOVAC_T2103
+    },
+    """35C T2117 """
+    'T2117': {
+        'fan_speeds': FAN_SPEEDS,
+        'support': SUPPORT_ROBOVAC_T2117
     }
 }
 


### PR DESCRIPTION
Added Turbo mode which is available with the Eufy robovac G30 Verge, along with the product code for the G30.

Have also updated the vacuum status layout so that it reports without an error, while still reporting correctly, such as adding a charging status, which gets switched to Docked once 100% charge is reached.

Please test fully, I only have a G30 Verge to test with, but the changes made should be compatible with the older one. If not, let me know. 